### PR TITLE
Added FLINT Handbook Github Link Issue #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Handbook
 ## Introduction 
-[FLINT Handbook](https://moja-global.github.io/Handbook/) is intended to provide an introduction to FLINT so that its readers, regardless of their knowledge level can understand what FLINT aims to accomplish. The FLINT handbook will go over climate science, the problems it poses to our environment, and the steps we can take to mitigate its effects.
+[FLINT Handbook](https://moja-global.github.io/Handbook/) is intended to provide an introduction to FLINT so that its readers, regardless of their knowledge level can understand what FLINT aims to accomplish. The FLINT handbook will go over climate science, the problems it poses to our environment, and the steps we can take to mitigate it's effects.
 
 The Handbook covers:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@
 
 The Handbook covers:
 
-This repository contains FLINT Handbook
+- Understanding Climate Science and Organizations championing the cause.
+- Use of carbon models like the Generic Carbon Budget Model (GCBM).
+- Introduction to Full Lands and Integration tools.
+- Role of Data Version Control (DVC) in Land Sector Dataset Repos.
+- Running a GCBM Silmulation.
+- Discussion on Climate Science and Projections.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Handbook
 
-This repository contains FLINT Handbook
+This repository contains [FLINT Handbook](https://moja-global.github.io/Handbook/)  
 
 ## Installation
 
@@ -14,9 +14,11 @@ Here are the steps you can follow while setting up the documentation locally.
 
 If you choose to setup the documentation website locally, you need to have Python and the Python package manager `pip` on your local machine. Follow the official [Python installation](https://www.python.org/downloads/) to setup Python on your local machine.
 
-First make a fork, and then clone the repo:
+First make a fork, and then clone the repo
 
-2. Clone the repository. Replace the `<GITHUB_USERNAME>` with your GitHub username. You can find your username by clicking on your profile picture in the top right corner of the GitHub website.
+2. Clone the repository 
+
+Replace the `<GITHUB_USERNAME>` with your GitHub username. You can find your username by clicking on your profile picture in the top right corner of the GitHub website.
 
 ```sh
 git clone https://github.com/<GITHUB_USERNAME>/Handbook

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # Handbook
+## Introduction 
+[FLINT Handbook](https://moja-global.github.io/Handbook/) is intended to provide an introduction to FLINT so that its readers, regardless of their knowledge level can understand what FLINT aims to accomplish. The FLINT handbook will go over climate science, the problems it poses to our environment, and the steps we can take to mitigate its effects.
 
-This repository contains [FLINT Handbook](https://moja-global.github.io/Handbook/)  
+The Handbook covers:
+
+- Understanding Climate Science and Organizations championing the cause.
+- Use of carbon models like the Generic Carbon Budget Model (GCBM).
+- Introduction to Full Lands and Integration tools.
+- Role of Data Version Control (DVC) in Land Sector Dataset Repos.
+- Running a GCBM Silmulation.
+- Discussion on Climate Science and Projections.
 
 ## Installation
 


### PR DESCRIPTION
In this repository, I have added the FLINT Handbook link to the ReadMe of Handbook Repository. Specifically, the introduction to the FLINT Handbook along with a description of what the handbook contains is mentioned in points. I have taken reference from the community website repository- introduction and studied through the FLINT Handbook. 

Issue - https://github.com/moja-global/Handbook/issues/2